### PR TITLE
Add ability to use ERB templating in YAML config files

### DIFF
--- a/lib/wraith/wraith.rb
+++ b/lib/wraith/wraith.rb
@@ -1,10 +1,11 @@
 require 'yaml'
+require 'erb'
 
 class Wraith::Wraith
   attr_accessor :config
 
   def initialize(config_name)
-    @config = YAML::load(ERB.new(File.read("configs/#{config_name}.yaml")).result)[ENV]
+    @config = YAML::load(ERB.new(File.read("configs/#{config_name}.yaml")).result)
   end
 
   def base_browser

--- a/lib/wraith/wraith.rb
+++ b/lib/wraith/wraith.rb
@@ -4,7 +4,7 @@ class Wraith::Wraith
   attr_accessor :config
 
   def initialize(config_name)
-    @config = YAML::load(File.open("configs/#{config_name}.yaml"))
+    @config = YAML::load(ERB.new(File.read("configs/#{config_name}.yaml")).result)[ENV]
   end
 
   def base_browser


### PR DESCRIPTION
This PR adds the ability to use ERB templating inside of YAML config files. I added this functionality because the Selenium grid I am using (Sauce Labs) requires a basic authentication scheme in its connection URL. This would mean in order to commit my YAML config files to the repo, I would have to commit a secret access key to Git.

With this pull request, you can now template variables in the YAML using ERB. For instance,

```
grid_url: <%= "http://" + ENV['SAUCE_USERNAME'] + ":" + ENV['SAUCE_ACCESS_KEY'] + "@localhost:4445/wd/hub" %>
```

will use environment variables `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` to compile the `grid_url` variable when the YAML file is imported, so these two secrets can live in the server environment rather than the Git repo.